### PR TITLE
Updates opennms repository url to https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <repository>
       <id>mibble</id>
       <name>Open NMS Repository (for Mibble)</name>
-      <url>http://maven.opennms.org/content/groups/opennms.org-release</url>
+      <url>https://maven.opennms.org/content/groups/opennms.org-release</url>
       <releases><enabled>true</enabled></releases>
     </repository>
   </repositories>


### PR DESCRIPTION
Maven 3.8.x (and 3.7.x possibly) disables all insecure repositories http:// by default.